### PR TITLE
Fix spelling of exclusiveMinimum.

### DIFF
--- a/jsl/fields.py
+++ b/jsl/fields.py
@@ -314,7 +314,7 @@ class NumberField(BaseSchemaField):
             schema['minimum'] = minimum
         exclusive_minimum = self.resolve_attr('exclusive_minimum', role).value
         if exclusive_minimum:
-            schema['exclusiveMinumum'] = exclusive_minimum
+            schema['exclusiveMinimum'] = exclusive_minimum
         maximum = self.resolve_attr('maximum', role).value
         if maximum is not None:
             schema['maximum'] = maximum

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -107,7 +107,7 @@ def test_number_and_int_fields():
     f = fields.NumberField(minimum=0, maximum=10, exclusive_minimum=True, exclusive_maximum=True)
     assert f.get_definitions_and_schema() == ({}, {
         'type': 'number',
-        'exclusiveMinumum': True,
+        'exclusiveMinimum': True,
         'exclusiveMaximum': True,
         'minimum': 0,
         'maximum': 10,


### PR DESCRIPTION
With the existing spelling, a value equal to the set minimum will still validate -- incorrectly.