### PR TITLE
Introduce missing NullField

### DIFF
--- a/jsl/fields/primitive.py
+++ b/jsl/fields/primitive.py
@@ -8,7 +8,7 @@ from .util import validate, validate_regex
 
 __all__ = [
     'StringField', 'BooleanField', 'EmailField', 'IPv4Field', 'DateTimeField',
-    'UriField', 'NumberField', 'IntField'
+    'UriField', 'NumberField', 'IntField', 'NullField'
 ]
 
 
@@ -147,3 +147,14 @@ class NumberField(BaseSchemaField):
 class IntField(NumberField):
     """An integer field."""
     _NUMBER_TYPE = 'integer'
+
+
+class NullField(BaseSchemaField):
+    """A null field."""
+
+    def get_definitions_and_schema(self, role=DEFAULT_ROLE, res_scope=EMPTY_SCOPE,
+                                   ordered=False, ref_documents=None):
+        id, res_scope = res_scope.alter(self.id)
+        schema = (OrderedDict if ordered else dict)(type='null')
+        schema = self._update_schema_with_common_fields(schema, id=id, role=role)
+        return {}, schema

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -382,3 +382,8 @@ def test_not_field():
         'not': {'type': 'string'},
     }
     assert f.get_schema() == expected_schema
+
+
+def test_null_field():
+    f = fields.NullField()
+    assert f.get_schema() == {'type': 'null'}


### PR DESCRIPTION
JSON Schema also supports describing [null values](https://spacetelescope.github.io/understanding-json-schema/about.html), but ``jsl`` somehow missed ``NullField``, this pull request fixes it.

ps. I copied ``NullField`` class from ``BooleanField`` and not sure that this is optimal decision