### PR TITLE
Allow specification of fields that have a default of null.

### DIFF
--- a/jsl/fields/base.py
+++ b/jsl/fields/base.py
@@ -3,7 +3,18 @@ from ..resolutionscope import ResolutionScope
 from ..roles import Resolvable, Resolution, DEFAULT_ROLE
 
 
-__all__ = ['BaseField', 'BaseSchemaField']
+__all__ = ['BaseField', 'BaseSchemaField', 'Null']
+
+
+class NullSentinel:
+    """class object for representing a Null value. Allows specifying fields
+    with a default value of null."""
+
+    def __bool__(self):
+        return False
+    __nonzero__ = __bool__
+
+Null = NullSentinel()
 
 
 class BaseField(Resolvable):
@@ -165,6 +176,8 @@ class BaseSchemaField(BaseField):
             schema['enum'] = list(enum)
         default = self.get_default(role=role)
         if default is not None:
+            if default is Null:
+                default = None
             schema['default'] = default
         return schema
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -15,6 +15,17 @@ def test_base_schema_field():
     assert not f.get_default()
     assert not f.get_enum()
 
+    assert f._update_schema_with_common_fields({}, id='qwerty') == {
+        'id': 'qwerty',
+    }
+
+    f = fields.BaseSchemaField(default=fields.Null)
+    assert not f.get_default()
+    assert f._update_schema_with_common_fields({}, id='qwerty') == {
+        'id': 'qwerty',
+        'default': None,
+    }
+
     f = fields.BaseSchemaField(required=True)
     assert f.required
 


### PR DESCRIPTION
This allows you to specify fields that have a default value of null.

I wanted to specify a field that can be null or some other value, with a default of null. Using the default of None as a sentinel for "no default" prevented me from doing this.

I'd normally have preferred to change the default parameter to a SENTINEL_NONE object that is merely an `object()` to allow None to represent null properly, but I can't do that without breaking API compatibility with the `get_default()` method.