### PR TITLE
Add new inheritance modes

### DIFF
--- a/docs/source/api/document.rst
+++ b/docs/source/api/document.rst
@@ -8,6 +8,10 @@ Document
 
 .. autodata:: ALL_OF
 
+.. autodata:: ANY_OF
+
+.. autodata:: ONE_OF
+
 .. autodata:: INLINE
 
 .. autoclass:: Options

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Introduction of two new inheritance modes, oneOf and anyOf, by Steven Seguin.
+
+0.2.2 2016-02-06
+----------------
+
+- Documentation fixes by mulhern <amulhern@redhat.com> (issue `#17`_).
+
+
 0.2.1 2015-11-23
 ~~~~~~~~~~~~~~~~
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -331,13 +331,14 @@ Now ``User.get_schema(ordered=True, role=DB_ROLE)`` returns the following schema
 
 Document Inheritance
 --------------------
-There are two inheritance modes available in JSL: **inline** and **all-of**.
+There are four inheritance modes available in JSL: **inline**, **all-of**, **any-of**, and **one-of**.
 
 In the inline mode (used by default), a schema of the child document contains a copy
 of its parent's fields.
 
-In the all-of mode a schema of the child document is an allOf validator that contains references
-to all parent schemas along with the schema that defines the child's fields.
+In the the other three modes a schema of the child document is a validator of the type allOf, anyOf,
+or oneOf that contains references to all parent schemas along with the schema that defines the
+child's fields.
 
 The inheritance mode can be set using the ``inheritance_mode`` document :class:`option <.Options>`.
 

--- a/jsl/__init__.py
+++ b/jsl/__init__.py
@@ -16,7 +16,7 @@ __version__ = '0.2.2'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 
 
-from .document import Document, ALL_OF, INLINE
+from .document import Document, ALL_OF, INLINE, ANY_OF, ONE_OF
 from .fields import *
 from .roles import *
 from .exceptions import SchemaGenerationException

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -8,7 +8,7 @@ from jsl.fields import (
     DateTimeField, ArrayField, OneOfField)
 from jsl._compat import OrderedDict, iterkeys
 
-from util import s
+from util import normalize
 
 
 def test_to_schema():
@@ -53,7 +53,7 @@ def test_to_schema():
             'author': Task.author.get_schema(),
         }
     }
-    assert s(Task.get_schema()) == expected_task_schema
+    assert normalize(Task.get_schema()) == expected_task_schema
 
 
 def test_document_options():
@@ -159,7 +159,7 @@ def test_recursive_definitions_1():
     }
     schema = A.get_schema(ordered=True)
     assert isinstance(schema, OrderedDict)
-    assert s(schema) == s(expected_schema)
+    assert normalize(schema) == normalize(expected_schema)
     assert list(iterkeys(schema)) == ['id', '$schema', 'definitions', '$ref']
 
     # let's make sure that all the references in resulting schema
@@ -237,7 +237,7 @@ def test_recursive_definitions_2():
         '$ref': '#/definitions/test_document.A',
     }
     schema = A.get_schema()
-    assert s(schema) == s(expected_schema)
+    assert normalize(schema) == normalize(expected_schema)
 
     # let's make sure that all the references in resulting schema
     # can be resolved
@@ -302,7 +302,7 @@ def test_recursive_definitions_3():
             }
         },
     }
-    assert s(Main.get_schema()) == s(expected_schema)
+    assert normalize(Main.get_schema()) == normalize(expected_schema)
 
 
 def test_recursive_definitions_4():
@@ -345,7 +345,7 @@ def test_recursive_definitions_4():
         'definitions': expected_definitions,
         '$ref': '#/definitions/test_document.Main',
     }
-    assert s(Main.get_schema()) == s(expected_schema)
+    assert normalize(Main.get_schema()) == normalize(expected_schema)
 
     class X(Document):
         name = StringField()
@@ -374,7 +374,7 @@ def test_recursive_definitions_4():
             }
         },
     }
-    assert s(Z.get_schema()) == s(expected_schema)
+    assert normalize(Z.get_schema()) == normalize(expected_schema)
 
 
 def test_recursive_definitions_5():
@@ -385,7 +385,7 @@ def test_recursive_definitions_5():
         with Scope('test') as test:
             test.field = DocumentField(RECURSIVE_REFERENCE_CONSTANT)
 
-    assert s(Test.get_schema(role='test')) == s({
+    assert normalize(Test.get_schema(role='test')) == normalize({
         '$schema': 'http://json-schema.org/draft-04/schema#',
         '$ref': '#/definitions/test',
         'definitions': {
@@ -416,7 +416,7 @@ def test_recursive_definitions_6():
             definition_id = 'a'
         derived_from = DocumentField(Children, as_ref=True)
 
-    assert s(A.get_schema()) == s({
+    assert normalize(A.get_schema()) == normalize({
         '$schema': 'http://json-schema.org/draft-04/schema#',
         'definitions': {
             'a': {

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -7,7 +7,7 @@ from jsl.fields.base import NullSentinel
 from jsl.document import Document
 from jsl._compat import OrderedDict
 
-from util import s
+from util import normalize
 
 
 def test_null_sentinel():
@@ -58,7 +58,7 @@ def test_base_schema_field():
 def test_string_field():
     f = fields.StringField()
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {'type': 'string'}
+    assert normalize(schema) == {'type': 'string'}
 
     f = fields.StringField(min_length=1, max_length=10, pattern='^test$',
                            enum=('a', 'b', 'c'), title='Pururum')
@@ -72,10 +72,10 @@ def test_string_field():
         ('maxLength', 10),
     ]
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == dict(expected_items)
+    assert normalize(schema) == dict(expected_items)
     definitions, ordered_schema = f.get_definitions_and_schema(ordered=True)
     assert isinstance(ordered_schema, OrderedDict)
-    assert s(ordered_schema) == OrderedDict(expected_items)
+    assert normalize(ordered_schema) == OrderedDict(expected_items)
 
     with pytest.raises(ValueError) as e:
         fields.StringField(pattern='(')
@@ -85,28 +85,28 @@ def test_string_field():
 def test_string_derived_fields():
     f = fields.EmailField()
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'string',
         'format': 'email',
     }
 
     f = fields.IPv4Field()
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'string',
         'format': 'ipv4',
     }
 
     f = fields.DateTimeField()
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'string',
         'format': 'date-time',
     }
 
     f = fields.UriField()
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'string',
         'format': 'uri',
     }
@@ -115,7 +115,7 @@ def test_string_derived_fields():
 def test_number_and_int_fields():
     f = fields.NumberField(multiple_of=10)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'number',
         'multipleOf': 10,
     }
@@ -123,7 +123,7 @@ def test_number_and_int_fields():
     f = fields.NumberField(minimum=0, maximum=10,
                            exclusive_minimum=True, exclusive_maximum=True)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'number',
         'exclusiveMinimum': True,
         'exclusiveMaximum': True,
@@ -133,14 +133,14 @@ def test_number_and_int_fields():
 
     f = fields.NumberField(enum=(1, 2, 3))
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'number',
         'enum': [1, 2, 3],
     }
 
     f = fields.IntField()
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'integer',
     }
 
@@ -151,7 +151,7 @@ def test_array_field_to_schema():
 
     f = fields.ArrayField(s_f)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'array',
         'items': s_f.get_schema(),
     }
@@ -170,14 +170,14 @@ def test_array_field_to_schema():
                           min_items=0, max_items=10, unique_items=True,
                           additional_items=d_f)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == dict(expected_items)
+    assert normalize(schema) == dict(expected_items)
     definitions, ordered_schema = f.get_definitions_and_schema(ordered=True)
     assert isinstance(ordered_schema, OrderedDict)
-    assert s(ordered_schema) == OrderedDict(expected_items)
+    assert normalize(ordered_schema) == OrderedDict(expected_items)
 
     f = fields.ArrayField(s_f, additional_items=True)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'array',
         'items': s_f.get_schema(),
         'additionalItems': True,
@@ -185,7 +185,7 @@ def test_array_field_to_schema():
 
     f = fields.ArrayField(s_f, additional_items=d_f)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'array',
         'items': s_f.get_schema(),
         'additionalItems': d_f.get_schema(),
@@ -195,7 +195,7 @@ def test_array_field_to_schema():
     a_f = fields.ArrayField(fields.StringField())
     f = fields.ArrayField([n_f, a_f])
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'array',
         'items': [n_f.get_schema(), a_f.get_schema()],
     }
@@ -221,7 +221,7 @@ def test_array_field_walk():
 def test_dict_field_to_schema():
     f = fields.DictField(title='Hey!', enum=[{'x': 1}, {'y': 2}])
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'object',
         'enum': [
             {'x': 1},
@@ -240,7 +240,7 @@ def test_dict_field_to_schema():
         'c*': c_field_mock,
     }, min_properties=5, max_properties=10)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'type': 'object',
         'properties': {
             'a': a_field_mock.get_schema(),
@@ -257,7 +257,7 @@ def test_dict_field_to_schema():
         (fields.StringField(), fields.NumberField()))
     f = fields.DictField(additional_properties=additional_prop_field_mock)
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == s({
+    assert normalize(schema) == normalize({
         'type': 'object',
         'additionalProperties': additional_prop_field_mock.get_schema(),
     })
@@ -272,7 +272,7 @@ def test_dict_field_to_schema():
         'c*': fields.StringField(name='C', required=True),
     })
     definitions, schema = f.get_definitions_and_schema()
-    assert s(schema) == s({
+    assert normalize(schema) == normalize({
         'type': 'object',
         'properties': {
             'a': {'type': 'string'},
@@ -325,12 +325,12 @@ def test_document_field():
     assert not definitions
 
     definitions, schema = f.get_definitions_and_schema(ref_documents=set([document_cls_mock]))
-    assert s(schema) == {'$ref': '#/definitions/document.Document'}
+    assert normalize(schema) == {'$ref': '#/definitions/document.Document'}
 
     f = fields.DocumentField(document_cls_mock, as_ref=True)
     definitions, schema = f.get_definitions_and_schema()
     assert definitions == {'document.Document': expected_schema}
-    assert s(schema) == {'$ref': '#/definitions/document.Document'}
+    assert normalize(schema) == {'$ref': '#/definitions/document.Document'}
 
     attrs = {
         'get_definitions_and_schema.return_value': ({}, expected_schema),
@@ -376,7 +376,7 @@ def test_recursive_document_field():
         },
         '$ref': '#/definitions/test_fields.Tree',
     }
-    assert s(Tree.get_schema()) == s(expected_schema)
+    assert normalize(Tree.get_schema()) == normalize(expected_schema)
 
 
 def test_of_fields():
@@ -387,19 +387,19 @@ def test_of_fields():
 
     f = fields.OneOfField(of_fields)
     _, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'oneOf': [f.get_schema() for f in of_fields]
     }
 
     f = fields.AnyOfField(of_fields)
     _, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'anyOf': [f.get_schema() for f in of_fields]
     }
 
     f = fields.AllOfField(of_fields)
     _, schema = f.get_definitions_and_schema()
-    assert s(schema) == {
+    assert normalize(schema) == {
         'allOf': [f.get_schema() for f in of_fields]
     }
 
@@ -410,12 +410,12 @@ def test_not_field():
         'description': 'Not a string.',
         'not': {'type': 'string'},
     }
-    assert s(f.get_schema()) == expected_schema
+    assert normalize(f.get_schema()) == expected_schema
 
 
 def test_null_field():
     f = fields.NullField()
-    assert s(f.get_schema()) == {'type': 'null'}
+    assert normalize(f.get_schema()) == {'type': 'null'}
 
 
 def test_ref_field():

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -8,7 +8,7 @@ from jsl import (Document, BaseSchemaField, StringField, ArrayField,
 from jsl.roles import Var, Scope, not_, Resolution
 from jsl.exceptions import SchemaGenerationException
 
-from util import s, sort_required_keys
+from util import normalize, sort_required_keys
 
 
 def test_var():
@@ -218,10 +218,10 @@ def test_base_field():
 def test_string_field():
     _ = lambda value: Var({'role_1': value})
     field = StringField(format=_('date-time'), min_length=_(1), max_length=_(2))
-    assert s(field.get_schema()) == s({
+    assert normalize(field.get_schema()) == normalize({
         'type': 'string'
     })
-    assert s(field.get_schema(role='role_1')) == s({
+    assert normalize(field.get_schema(role='role_1')) == normalize({
         'type': 'string',
         'format': 'date-time',
         'minLength': 1,
@@ -240,22 +240,22 @@ def test_array_field():
         'role_1': s_f,
         'role_2': n_f,
     }))
-    schema = s(field.get_schema(role='role_1'))
-    assert s(schema['items']) == s_f.get_schema()
+    schema = normalize(field.get_schema(role='role_1'))
+    assert normalize(schema['items']) == s_f.get_schema()
 
-    schema = s(field.get_schema(role='role_2'))
+    schema = normalize(field.get_schema(role='role_2'))
     assert schema['items'] == n_f.get_schema()
 
-    schema = s(field.get_schema())
+    schema = normalize(field.get_schema())
     assert 'items' not in schema
 
     _ = lambda value: Var({'role_1': value})
     field = ArrayField(s_f, min_items=_(1), max_items=_(2), unique_items=_(True), additional_items=_(True))
-    assert s(field.get_schema()) == s({
+    assert normalize(field.get_schema()) == normalize({
         'type': 'array',
         'items': s_f.get_schema(),
     })
-    assert field.get_schema(role='role_1') == s({
+    assert field.get_schema(role='role_1') == normalize({
         'type': 'array',
         'items': s_f.get_schema(),
         'minItems': 1,
@@ -281,10 +281,10 @@ def test_dict_field():
         },
         propagate='role_1'
     ), additional_properties=_(s_f), min_properties=_(1), max_properties=_(2))
-    assert s(field.get_schema()) == s({
+    assert normalize(field.get_schema()) == normalize({
         'type': 'object'
     })
-    assert s(field.get_schema(role='role_1')) == s({
+    assert normalize(field.get_schema(role='role_1')) == normalize({
         'type': 'object',
         'properties': {
             'name': s_f.get_schema(),
@@ -296,7 +296,7 @@ def test_dict_field():
         'minProperties': 1,
         'maxProperties': 2,
     })
-    assert s(field.get_schema(role='role_2')) == s({
+    assert normalize(field.get_schema(role='role_2')) == normalize({
         'type': 'object',
         'properties': {},
         'patternProperties': {},
@@ -310,13 +310,13 @@ def test_keyword_of_fields(keyword, field_cls):
     n_f = NumberField()
     i_f = IntField()
     field = field_cls([n_f, Var({'role_1': s_f}), Var({'role_2': i_f})])
-    assert s(field.get_schema()) == {
+    assert normalize(field.get_schema()) == {
         keyword: [n_f.get_schema()]
     }
-    assert s(field.get_schema(role='role_1')) == {
+    assert normalize(field.get_schema(role='role_1')) == {
         keyword: [n_f.get_schema(), s_f.get_schema()]
     }
-    assert s(field.get_schema(role='role_2')) == {
+    assert normalize(field.get_schema(role='role_2')) == {
         keyword: [n_f.get_schema(), i_f.get_schema()]
     }
 
@@ -324,7 +324,7 @@ def test_keyword_of_fields(keyword, field_cls):
         'role_1': [n_f, Var({'role_1': s_f}), Var({'role_2': i_f})],
         'role_2': [Var({'role_2': i_f})],
     }, propagate='role_1'))
-    assert s(field.get_schema(role='role_1')) == {
+    assert normalize(field.get_schema(role='role_1')) == {
         keyword: [n_f.get_schema(), s_f.get_schema()]
     }
     with pytest.raises(SchemaGenerationException):
@@ -334,7 +334,7 @@ def test_keyword_of_fields(keyword, field_cls):
 def test_not_field():
     s_f = StringField()
     field = NotField(Var({'role_1': s_f}))
-    assert s(field.get_schema(role='role_1')) == {'not': s_f.get_schema()}
+    assert normalize(field.get_schema(role='role_1')) == {'not': s_f.get_schema()}
 
 
 def test_document_field():
@@ -389,7 +389,7 @@ def test_basics():
         created_at = DateTimeField(required=True)
         author = Var({'response': DocumentField(User)})
 
-    assert s(Task.get_schema()) == s({
+    assert normalize(Task.get_schema()) == normalize({
         '$schema': 'http://json-schema.org/draft-04/schema#',
         'additionalProperties': False,
         'description': 'A task.',
@@ -404,7 +404,7 @@ def test_basics():
         'type': 'object'
     })
 
-    assert s(Task.get_schema(role='response')) == s({
+    assert normalize(Task.get_schema(role='response')) == normalize({
         '$schema': 'http://json-schema.org/draft-04/schema#',
         'title': 'Task',
         'description': 'A task.',

--- a/tests/util.py
+++ b/tests/util.py
@@ -20,7 +20,7 @@ def sort_required_keys(schema):
                     sort_required_keys(v)
 
 
-def s(schema):
+def normalize(schema):
     jsonschema.Draft4Validator.check_schema(schema)
     sort_required_keys(schema)
     return schema


### PR DESCRIPTION
These changes expose two new inheritance modes, `ONE_OF` and `ANY_OF`, to provide more flexible schema combinations.