### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ License
 
 `BSD license`_
 
-.. _Documentation: http://jsl.readthedocs.org/
+.. _Documentation: https://jsl.readthedocs.io/
 .. _GitHub: https://github.com/aromanovich/jsl
 .. _PyPI: https://pypi.python.org/pypi/jsl
 .. _BSD license: https://github.com/aromanovich/jsl/blob/master/LICENSE

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -46,7 +46,7 @@ a generated schema.
 
 .. links
 
-.. _Python implementation: https://python-jsonschema.readthedocs.org/en/latest/
+.. _Python implementation: https://python-jsonschema.readthedocs.io/en/latest/
 .. _JSON Schema: http://json-schema.org/
 
 Quick Example

--- a/jsl/__init__.py
+++ b/jsl/__init__.py
@@ -3,7 +3,7 @@
 JSL
 ===
 A Python DSL for describing JSON schemas.
-See http://jsl.rtfd.org/ for documentation.
+See https://jsl.readthedocs.io/ for documentation.
 :copyright: (c) 2016 Anton Romanovich
 :license: BSD
 """

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     license='BSD',
     author='Anton Romanovich',
     author_email='anthony.romanovich@gmail.com',
-    url='https://jsl.readthedocs.org',
+    url='https://jsl.readthedocs.io',
     packages=find_packages(exclude=['tests']),
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.